### PR TITLE
Refactor the code

### DIFF
--- a/public/application/app.js
+++ b/public/application/app.js
@@ -300,7 +300,7 @@ function renderDrawing(infos) {
     drawing.classList.add("drawing");
 
     const a = document.createElement("a");
-    a.href = `./../canvas.html?drawing=${infos.name}&section=${asideSelectedSection}`;
+    a.href = `./public/canvas.html?drawing=${infos.name}&section=${asideSelectedSection}`;
     const img = document.createElement("img");
     img.src = URL.createObjectURL(infos.img);
     img.onload = function () {

--- a/public/application/canvas.js
+++ b/public/application/canvas.js
@@ -668,7 +668,7 @@ function handleMouseOrTouchMove(event){
     if (isDrawing && currentDrawingMode === "free") {
         draw.strokeLineTo(getEventPos(event).x - 2, getEventPos(event).y - 2);
     } else {
-        if(isDrawing){
+        if(isDrawing && currentDrawingMode !== "line"){
             previewDraw.clear();
             previewDraw.rectangle(lowestPosition.x, lowestPosition.y, getEventPos(event).x - lowestPosition.x, getEventPos(event).y - lowestPosition.y);
         }

--- a/public/application/canvas.js
+++ b/public/application/canvas.js
@@ -915,7 +915,7 @@ closeCanvasBtn.addEventListener('click', function () {
 
     const saveBtn = document.createElement("button");
     const saveLinkWrraper = document.createElement("a");
-    saveLinkWrraper.href = "index.html";
+    saveLinkWrraper.href = "../index.html";
     saveLinkWrraper.textContent = "Salvar";
     saveLinkWrraper.addEventListener('click', function () {
         canvas.toBlob((blob) => {
@@ -926,7 +926,7 @@ closeCanvasBtn.addEventListener('click', function () {
 
     const doNotSaveBtn = document.createElement("button");
     const doNotSaveLinkWrraper = document.createElement("a");
-    doNotSaveLinkWrraper.href = "index.html";
+    doNotSaveLinkWrraper.href = "../index.html";
     doNotSaveLinkWrraper.textContent = "Não salvar";
     doNotSaveBtn.appendChild(doNotSaveLinkWrraper);
 

--- a/public/canvas.html
+++ b/public/canvas.html
@@ -10,7 +10,8 @@
 
 <body>
     <button id="return">&lt;- Voltar</button>
-    <canvas id="main-canvas" height="999" width="999"></canvas>
+    <canvas id="drawing-preview" class="shape-size"></canvas>
+    <canvas id="main-canvas" height="999" width="999">Your browser do not support the canvas element.</canvas>
     <div id="drawing-options">
         <div id="resizer-wrraper">
             <div id="resizer"></div>

--- a/public/css/canvas.css
+++ b/public/css/canvas.css
@@ -1,12 +1,12 @@
 :root {
-  --shape-selector-not-resized-height: 60.44px;
+    --shape-selector-not-resized-height: 60.44px;
 }
-        
+
 * {
     font-family: Arial, Helvetica, sans-serif;
     box-sizing: border-box;
 }
-        
+
 body,
 html {
     height: 100%;
@@ -15,6 +15,10 @@ html {
     margin: 0;
     padding: 0;
     color: var(--principal-color);
+}
+
+#main-canvas {
+    image-rendering: pixelated;
 }
 
 #return {
@@ -75,11 +79,9 @@ html {
     margin: 0;
     padding: var(--shape-selector-button-padding);
     border: 0;
-    background-color: var(
-    --button-background-color);
+    background-color: var(--button-background-color);
     border-radius: 4px;
-    box-shadow: 1px 1px 0 0 gray, var(
-    --inset-shape-box-shadow);
+    box-shadow: 1px 1px 0 0 gray, var(--inset-shape-box-shadow);
 }
 
 #shape-selector button:hover {
@@ -201,7 +203,7 @@ html {
     max-width: 100px;
 }
 
-#caracteristics > div[data-text-caracteristic] {
+#caracteristics>div[data-text-caracteristic] {
     display: flex;
     flex-wrap: nowrap;
     justify-content: space-between;
@@ -226,18 +228,19 @@ dialog {
     background-color: var(--principal-background-color);
 }
 
-dialog > p {
+dialog>p {
     margin: 10px 0;
 }
 
-dialog button > a, dialog button {
+dialog button>a,
+dialog button {
     text-decoration: underline;
     color: var(--principal-color);
     background-color: var(--button-background-color);
     border-radius: 7px;
 }
 
-@media screen and (min-width: 560px){
+@media screen and (min-width: 560px) {
     #drawing-options.resized #drawing-type {
         margin: 0;
     }
@@ -247,14 +250,15 @@ dialog button > a, dialog button {
     }
 }
 
-@media screen and (max-width: 400px){
+@media screen and (max-width: 400px) {
+
     /* this grid design was created for 10 elements in the grid,
        if this changes, this design will have to change too.*/
     #shape-selector div {
         grid-template-columns: repeat(4, 1fr);
     }
 
-    #shape-selector #shapes :nth-child(n+9){
+    #shape-selector #shapes :nth-child(n+9) {
         grid-column: span 2;
     }
 }

--- a/public/css/canvas.css
+++ b/public/css/canvas.css
@@ -207,6 +207,14 @@ html {
     justify-content: space-between;
 }
 
+#drawing-preview {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    display: none;
+}
+
 .active {
     background-color: orange !important;
 }


### PR DESCRIPTION
Refactor the code, fix the URLs you are directed to when opening and leaving the drawing editor, and more.

## changes
- Fix the URLs you are directed to when you try to open or leave the drawing editor.
- When the width of the line that is being drawn is an odd number, the canvas is translated in 0.5 pixel in both X and Y to increase the sharpness and crisp-looking of the image.
- Apply `image-rendering: pixelated` to the canvas to show the image in a more pixelated way.
- If the current drawing mode is 'line', do not draw the box that delimits the size of the object (or shape) being drawn.
- Refactor the code: 
  - rename some variables;
  - add variables to elements that are frequently used;
  - add a id to almost each element of the div caracteristics to put the id of the element and then the id of his childs, instead of having the order of the elements in the head and getting an element by his position in the div;
  - remove duplicated code (put in a function or rewrite in a better way) and duplicated styling in the code by having it in the CSS file;
  - etc.